### PR TITLE
add r_in_tagged_strings

### DIFF
--- a/lua/injectme/preset_injections.lua
+++ b/lua/injectme/preset_injections.lua
@@ -252,6 +252,16 @@ foo(/* html */ `<span>`)]],
       ]],
       description = "JSON syntax in all strings in call expressions that are method calls named 'loads'",
     },
+    r_in_tagged_strings = {
+      code = [[
+		(string
+			(string_content) @injection.content
+			  (#vim-match? @injection.content "#R")
+			  (#set! injection.language "r")
+		)
+	]],
+      description = "R syntax in all strings that contain #R",
+    },
   },
 }
 


### PR DESCRIPTION
I often use rpy2 to use R from python - this highlights all strings tagged with #R in their contents.

Thanks for building this btw., it was really nice to get started hacking with this!. Very shallow 'try it out, here's how to do it' curve!

Now if I only could get neovim to use different themes for different injected languages :).